### PR TITLE
Update horizontal card text

### DIFF
--- a/static/data.json
+++ b/static/data.json
@@ -277,7 +277,7 @@
   {
     "img": "",
     "title": "6 of Cups Reversed",
-    "text": "(This card has a horizontal orientation, therefore it incorporates upright and reversed meanings simultaneously.)"
+    "text": "It's playtime, nostalgia is perfect, just be aware when you are drinking its sweet nectar.\n\n(This card has a horizontal orientation, therefore it incorporates upright and reversed meanings simultaneously.)"
   },
   {
     "img": "IMG_0C07.jpg",
@@ -617,7 +617,7 @@
   {
     "img": "",
     "title": "Knight of Swords Reversed",
-    "text": "(This card has a horizontal orientation, therefore it incorporates upright and reversed meanings simultaneously.)"
+    "text": "Your ideas leap ahead, your words rush forth, be reasonable and careful not to cut those around you.\n\n(This card has a horizontal orientation, therefore it incorporates upright and reversed meanings simultaneously.)"
   },
   {
     "img": "IMG_0S13.jpg",


### PR DESCRIPTION
There are two horizontal cards in the deck. The horizontal cards are considered to have the same meaning in both the upright and reversed orientations. The "reversed" text references the "upright" text without actually providing the text from the upright card. This change adds the "upright" text of the card to the "reversed" text. 

(Changes untested)